### PR TITLE
Add warning about type definitions

### DIFF
--- a/_pages/typecheck.md
+++ b/_pages/typecheck.md
@@ -46,6 +46,8 @@ local a2: A = b1 -- ok
 local b2: B = a1 -- not ok
 ```
 
+Note that the types are defined before use. Using types defined later in a file can result in unexpected and misleading behavior.
+
 ## Builtin types
 
 Lua VM supports 8 primitive types: `nil`, `string`, `number`, `boolean`, `table`, `function`, `thread`, and `userdata`. Of these, `table` and `function` are not represented by name, but have their dedicated syntax as covered in this [syntax document](syntax), and `userdata` is represented by [concrete types](#roblox-types); other types can be specified by their name.


### PR DESCRIPTION
Motivation: The annotation of `object` in this code sample is completely disregarded by the type engine.
```lua
function f(fn: (any) -> ())
    return fn
end

f(function(object: Object)
    object.value += 1
end)

local function new(value: number)
    return {
        value = value,
    }
end

type Object = typeof(new(...))
```

![image](https://github.com/luau-lang/site/assets/94771866/004f5b54-35db-45a4-baee-0b808a91a72e)

The issue is fixed by moving the type before the line that uses it:

![image](https://github.com/luau-lang/site/assets/94771866/d8f034d5-2b5f-43d4-b93c-0cb99f223a8c)

An addition to the documentation to warn users about misleading behavior when using types declared later in the file would help to alleviate the issue until this is fixed.