### PR TITLE
Add documentation about `buffer` primitive

### DIFF
--- a/_pages/library.md
+++ b/_pages/library.md
@@ -122,7 +122,7 @@ Converts the input object to string and returns the result. If the object has a 
 function type(obj: any): string
 ```
 
-Returns the type of the object, which is one of `"nil"`, `"boolean"`, `"number"`, `"vector"`, `"string"`, `"table"`, `"function"`, `"userdata"` or `"thread"`.
+Returns the type of the object, which is one of `"nil"`, `"boolean"`, `"number"`, `"vector"`, `"string"`, `"table"`, `"function"`, `"userdata"`, `"thread"`, or `"buffer"`.
 
 ```
 function typeof(obj: any): string

--- a/_pages/typecheck.md
+++ b/_pages/typecheck.md
@@ -48,7 +48,7 @@ local b2: B = a1 -- not ok
 
 ## Builtin types
 
-Lua VM supports 8 primitive types: `nil`, `string`, `number`, `boolean`, `table`, `function`, `thread`, and `userdata`. Of these, `table` and `function` are not represented by name, but have their dedicated syntax as covered in this [syntax document](syntax), and `userdata` is represented by [concrete types](#roblox-types); other types can be specified by their name.
+The Luau VM supports 9 primitive types: `nil`, `string`, `number`, `boolean`, `table`, `function`, `thread`, `userdata`, and `buffer`. Of these, `table` and `function` are not represented by name, but have their dedicated syntax as covered in this [syntax document](syntax), and `userdata` is represented by [concrete types](#roblox-types); other types can be specified by their name.
 
 The type checker also provides the builtin types [`unknown`](#unknown-type), [`never`](#never-type), and [`any`](#any-type).
 


### PR DESCRIPTION
- Adds relevant details about `buffer` being a primitive of Luau
- Documents `buffer` being a possible return of the `type` global function.