### PR TITLE
Minor updates to Getting Started and Type Check page

### DIFF
--- a/_pages/getting-started.md
+++ b/_pages/getting-started.md
@@ -4,6 +4,8 @@ title: Getting Started
 toc: true
 ---
 
+Luau is a fast, small, safe, gradually typed embeddable scripting language derived from Lua 5.1. Luau ships as a command line tool for running, analyzing, and linting your Luau scripts. Luau is integrated with RobloxStudio and is automatically enabled with the `--!strict` flag at the top of any scripts. Roblox developers should also visit our [Creator Docs Luau Section](https://create.roblox.com/docs/luau).
+
 To get started with Luau you need to use `luau` command line binary to run your code and `luau-analyze` to run static analysis (including type checking and linting). You can download these from [a recent release](https://github.com/luau-lang/luau/releases).
 
 ## Creating a script

--- a/_pages/typecheck.md
+++ b/_pages/typecheck.md
@@ -521,14 +521,16 @@ Which works out because `value: T` exists only when `type` is in actual fact `"o
 
 ## Type refinements
 
-When we check the type of any lvalue (a global, a local, or a property), what we're doing is we're refining the type, hence "type refinement." The support for this is arbitrarily complex, so go crazy!
+When we check the type of any lvalue (a global, a local, or a property), what we're doing is we're refining the type, hence "type refinement." The support for this is arbitrarily complex, so go at it!
 
 Here are all the ways you can refine:
 1. Truthy test: `if x then` will refine `x` to be truthy.
 2. Type guards: `if type(x) == "number" then` will refine `x` to be `number`.
-3. Equality: `x == "hello"` will refine `x` to be a singleton type `"hello"`.
+3. Equality: `if x == "hello" then` will refine `x` to be a singleton type `"hello"`.
 
-And they can be composed with many of `and`/`or`/`not`. `not`, just like `~=`, will flip the resulting refinements, that is `not x` will refine `x` to be falsy.
+And they can be composed with many of `and`/`or`/`not`. `not`, just like `~=`, will flip the resulting refinements, that is `not x` will refine `x` to be falsy. 
+
+The `assert(..)` function may also be used to refine types instead of `if/then`.
 
 Using truthy test:
 ```lua

--- a/_pages/typecheck.md
+++ b/_pages/typecheck.md
@@ -626,11 +626,22 @@ When one type inherits from another type, the type checker models this relations
 
 All enums are also available to use by their name as part of the `Enum` type library, e.g. `local m: Enum.Material = part.Material`.
 
-Finally, we can automatically deduce what calls like `Instance.new` and `game:GetService` are supposed to return:
+We can automatically deduce what calls like `Instance.new` and `game:GetService` are supposed to return:
 
 ```lua
 local part = Instance.new("Part")
 local basePart: BasePart = part
+```
+
+Finally, Roblox types can be refined using `isA`:
+
+```lua
+local function getText(x : Instance) : string
+    if x:isA("TextLabel") or x:isA("TextButton") or x:isA("TextBox") then
+		return child.Text
+    end
+    return ""
+end
 ```
 
 Note that many of these types provide some properties and methods in both lowerCase and UpperCase; the lowerCase variants are deprecated, and the type system will ask you to use the UpperCase variants instead.


### PR DESCRIPTION
This PR makes 3 minor edits:

- Update the Getting Started page to provide a little more clarity for Roblox Developers since they aren't using the luau command line tool directly
- Update the roblox types section of typecheck page to provide example on type refinement of Roblox types using `isA` 
- Update the type refinement section of the typecheck page to explain that `assert` can also be used and to use more inclusive language.

