### PR TITLE
Update performance block on landing page with JIT information

### DIFF
--- a/index.md
+++ b/index.md
@@ -43,7 +43,7 @@ feature_row3:
   - 
     title: Performance
     excerpt: >
-        In addition to a completely custom front end that implements parsing, linting and type checking, Luau runtime features new bytecode, interpreter and compiler that are heavily tuned for performance. Luau currently does not implement Just-In-Time compilation, but its interpreter can be competitive with LuaJIT interpreter depending on the program. We continue to optimize the runtime and rewrite portions of it to be even more efficient. While our overall goal is to minimize the amount of time programmers spend tuning performance, some details about the performance characteristics are [provided for inquisitive minds](performance).
+        In addition to a completely custom front end that implements parsing, linting and type checking, Luau runtime features new bytecode, interpreter and compiler that are heavily tuned for performance. Luau supports Just-In-Time compilation, and can be competitive with LuaJIT interpreter depending on the program. We continue to optimize the runtime and rewrite portions of it to be even more efficient. While our overall goal is to minimize the amount of time programmers spend tuning performance, some details about the performance characteristics are [provided for inquisitive minds](performance).
 
   -
     title: Libraries

--- a/index.md
+++ b/index.md
@@ -43,7 +43,7 @@ feature_row3:
   - 
     title: Performance
     excerpt: >
-        In addition to a completely custom front end that implements parsing, linting and type checking, Luau runtime features new bytecode, interpreter and compiler that are heavily tuned for performance. Luau supports Just-In-Time compilation, and can be competitive with LuaJIT interpreter depending on the program. We continue to optimize the runtime and rewrite portions of it to be even more efficient. While our overall goal is to minimize the amount of time programmers spend tuning performance, some details about the performance characteristics are [provided for inquisitive minds](performance).
+        In addition to a completely custom front end that implements parsing, linting and type checking, Luau runtime features new bytecode, interpreter and compiler that are heavily tuned for performance. Luau supports Just-In-Time (JIT) compilation, which greatly improves performance of certain programs. We continue to optimize the runtime and rewrite portions of it to be even more efficient. While our overall goal is to minimize the amount of time programmers spend tuning performance, some details about the performance characteristics are [provided for inquisitive minds](performance).
 
   -
     title: Libraries


### PR DESCRIPTION
Currently, the landing page states that luau does not support JIT, although that is now untrue.

> ...Luau currently does not implement Just-In-Time compilation, but its interpreter can be competitive with LuaJIT interpreter depending on the program...

This PR introduces a minor update to the landing page to be up-to-date with the latest JIT work on luau.