### PR TITLE
fix GenericTypeListWithDefaults rule in the grammar

### DIFF
--- a/_pages/grammar.md
+++ b/_pages/grammar.md
@@ -77,9 +77,7 @@ GenericTypeList = NAME [',' GenericTypeList] | GenericTypePackParameter {',' Gen
 
 GenericTypePackParameterWithDefault = NAME '...' '=' (TypePack | VariadicTypePack | GenericTypePack)
 GenericTypeListWithDefaults =
-    GenericTypeList {',' GenericTypePackParameterWithDefault} |
-    NAME {',' NAME} {',' NAME '=' Type} {',' GenericTypePackParameterWithDefault} |
-    NAME '=' Type {',' GenericTypePackParameterWithDefault} |
+    NAME ['=' Type] [',' GenericTypeListWithDefaults] |
     GenericTypePackParameterWithDefault {',' GenericTypePackParameterWithDefault}
 
 TypeList = Type [',' TypeList] | '...' Type


### PR DESCRIPTION
In its current state, the rule does not allow for this valid syntax:
```lua
type A<T = number, U = string> = {}
```
I also think the rule was overly complex, and could be simplified to be more similar to `GenericTypeList`.