### PR TITLE
misc grammar fixes

### DIFF
--- a/_pages/grammar.md
+++ b/_pages/grammar.md
@@ -28,7 +28,7 @@ laststat = 'return' [explist] | 'break' | 'continue'
 
 funcname = NAME {'.' NAME} [':' NAME]
 funcbody = ['<' GenericTypeList '>'] '(' [parlist] ')' [':' ReturnType] block 'end'
-parlist = bindinglist [',' '...'] | '...' [':' (Type | GenericTypePack)]
+parlist = bindinglist [',' '...' [':' GenericTypePack | Type]]
 
 explist = {exp ','} exp
 namelist = NAME {',' NAME}
@@ -83,7 +83,7 @@ GenericTypeListWithDefaults =
     GenericTypePackParameterWithDefault {',' GenericTypePackParameterWithDefault}
 
 TypeList = Type [',' TypeList] | '...' Type
-BoundTypeList = [NAME ':'] Type [',' BoundTypeList] | '...' Type
+BoundTypeList = [NAME ':'] Type [',' BoundTypeList] | GenericTypePack | VariadicTypePack
 TypeParams = (Type | TypePack | VariadicTypePack | GenericTypePack) [',' TypeParams]
 TypePack = '(' [TypeList] ')'
 GenericTypePack = NAME '...'


### PR DESCRIPTION
The `BoundTypeList` rule previously didn't allow generic type packs, and the way it was written could be confusing as it was the contents of the `VariadicTypePack` rather than the actual `VariadicTypePack` rule.

The `parlist` rule previously would allow `a: type, b: type, ...` and `...: type` but it would not allow `a: type, b: type, ...: type`.