### PR TITLE
Fix parlist grammar, remove namelist

### DIFF
--- a/_pages/grammar.md
+++ b/_pages/grammar.md
@@ -28,10 +28,10 @@ laststat = 'return' [explist] | 'break' | 'continue'
 
 funcname = NAME {'.' NAME} [':' NAME]
 funcbody = ['<' GenericTypeList '>'] '(' [parlist] ')' [':' ReturnType] block 'end'
-parlist = bindinglist [',' '...' [':' GenericTypePack | Type]]
+
+parlist = bindinglist [',' '...' [':' (GenericTypePack | Type)]] | '...' [':' (GenericTypePack | Type)]
 
 explist = {exp ','} exp
-namelist = NAME {',' NAME}
 
 binding = NAME [':' Type]
 bindinglist = binding [',' bindinglist] (* equivalent of Lua 5.1 'namelist', except with optional type annotations *)

--- a/_pages/grammar.md
+++ b/_pages/grammar.md
@@ -28,7 +28,6 @@ laststat = 'return' [explist] | 'break' | 'continue'
 
 funcname = NAME {'.' NAME} [':' NAME]
 funcbody = ['<' GenericTypeList '>'] '(' [parlist] ')' [':' ReturnType] block 'end'
-
 parlist = bindinglist [',' '...' [':' (GenericTypePack | Type)]] | '...' [':' (GenericTypePack | Type)]
 
 explist = {exp ','} exp


### PR DESCRIPTION
parlist currently doesn't allow a lonely vararg expression as a function's parameter, and namelist isn't used.