### PR TITLE
Add user-defined type function to grammar

### DIFF
--- a/_pages/grammar.md
+++ b/_pages/grammar.md
@@ -22,7 +22,8 @@ stat = varlist '=' explist |
     attributes 'function' funcname funcbody |
     attributes 'local' 'function' NAME funcbody |
     'local' bindinglist ['=' explist] |
-    ['export'] 'type' NAME ['<' GenericTypeListWithDefaults '>'] '=' Type
+    ['export'] 'type' NAME ['<' GenericTypeListWithDefaults '>'] '=' Type |
+    ['export'] 'type' 'function' NAME funcbody
 
 laststat = 'return' [explist] | 'break' | 'continue'
 


### PR DESCRIPTION
Adds user-defined type functions to the grammar as a statement that looks as follows: `['export'] 'type' 'function' NAME funcbody`.