### PR TITLE
Note the behavior difference in 'xpcall'

### DIFF
--- a/_pages/compatibility.md
+++ b/_pages/compatibility.md
@@ -48,6 +48,7 @@ Sandboxing challenges are [covered in the dedicated section](sandbox).
 | feature | status | notes |
 |---------|--------|------|
 | yieldable pcall/xpcall | ✔️ | |
+| yieldable xpcall error handler | ❌ | no strong use cases, VM complexity and performance implications |
 | yieldable metamethods | ❌ | significant performance implications |
 | ephemeron tables | ❌ | this complicates and slows down the garbage collector esp. for large weak tables |
 | emergency garbage collector | 🤷‍ | Luau runs in environments where handling memory exhaustion in emergency situations is not tenable |


### PR DESCRIPTION
From the `yieldable pcall/xpcall` it is easy to assume everything about `pcall`/`xpcall` is yieldable, but it was actually only about the target function being called, not the error handler.
In Luau, yielding from `xpcall` error handler is considered an 'error in error handling'.
Lua 5.2 went really hard into yielding support from all locations, which comes with the complexity of each operator and especially the error handler which takes an extra record in the call info data.

This update notes this difference.