### PR TITLE
fix: update the website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This repository hosts the language documentation, which is accessible on https://luau-lang.org.
+This repository hosts the language documentation, which is accessible on https://luau.org.
 Changes to this documentation that improve clarity, fix grammatical issues, explain aspects that haven't been explained before and the like are warmly welcomed.
 
 Please feel free to [create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) to improve our documentation. Note that at this point the documentation is English-only.


### PR DESCRIPTION
Updates the website link to https://luau.org. 