### PR TITLE
Fix `table.find` library documentation missing optional parameter `init`

### DIFF
--- a/_pages/library.md
+++ b/_pages/library.md
@@ -451,10 +451,10 @@ Creates a table with `n` elements; all of them (range `[1..n]`) are set to `v`. 
 Note that preallocation is only performed for the array portion of the table - using `table.create` on dictionaries is counter-productive.
 
 ```
-function table.find<V>(t: {V}, v: V): number?
+function table.find<V>(t: {V}, v: V, init: number?): number?
 ```
 
-Find the first element in the table that is equal to `v` and returns its index; the traversal stops at the first `nil`. If the element is not found, `nil` is returned instead.
+Find the first element in the table that is equal to `v` and returns its index; the traversal stops at the first `nil`. If the element is not found, `nil` is returned instead. The traversal starts at index `init` if specified, otherwise 1.
 
 ```
 function table.clear(t: table)


### PR DESCRIPTION
The [`table.find` RFC](https://github.com/luau-lang/rfcs/blob/master/docs/function-table-create-find.md) mentions an `init` parameter implemented [here](https://github.com/luau-lang/luau/blob/640ebbc0a51bef0daa7c9b8c943d522dacb6a9a8/VM/src/ltablib.cpp#L529-L531) but missing from the doc site's library function documentation for `table.find`. This PR fixes the type signature of `table.find` to reflect the `init` parameter and adds a sentence explaining traversal start. 