### PR TITLE
Update grammar.md with assignment consistency

### DIFF
--- a/_pages/grammar.md
+++ b/_pages/grammar.md
@@ -4,13 +4,13 @@ title: Grammar
 classes: wide
 ---
 
-This is the complete syntax grammar for Luau in EBNF. More information about the terminal nodes String and Number
+This is the complete syntax grammar for Luau in EBNF. More information about the terminal nodes STRING and NUMBER
 is available in the [syntax section](syntax).
 
 ```ebnf
-chunk = block
-block = {stat [';']} [laststat [';']]
-stat = varlist '=' explist |
+chunk ::= block
+block ::= {stat [';']} [laststat [';']]
+stat ::= varlist '=' explist |
     var compoundop exp |
     functioncall |
     'do' block 'end' |
@@ -25,37 +25,37 @@ stat = varlist '=' explist |
     ['export'] 'type' NAME ['<' GenericTypeListWithDefaults '>'] '=' Type |
     ['export'] 'type' 'function' NAME funcbody
 
-laststat = 'return' [explist] | 'break' | 'continue'
+laststat ::= 'return' [explist] | 'break' | 'continue'
 
-funcname = NAME {'.' NAME} [':' NAME]
-funcbody = ['<' GenericTypeList '>'] '(' [parlist] ')' [':' ReturnType] block 'end'
-parlist = bindinglist [',' '...' [':' (GenericTypePack | Type)]] | '...' [':' (GenericTypePack | Type)]
+funcname ::= NAME {'.' NAME} [':' NAME]
+funcbody ::= ['<' GenericTypeList '>'] '(' [parlist] ')' [':' ReturnType] block 'end'
+parlist ::= bindinglist [',' '...' [':' (GenericTypePack | Type)]] | '...' [':' (GenericTypePack | Type)]
 
-explist = {exp ','} exp
+explist ::= {exp ','} exp
 
-binding = NAME [':' Type]
-bindinglist = binding [',' bindinglist] (* equivalent of Lua 5.1 'namelist', except with optional type annotations *)
+binding ::= NAME [':' Type]
+bindinglist ::= binding [',' bindinglist] (* equivalent of Lua 5.1 'namelist', except with optional type annotations *)
 
-var = NAME | prefixexp '[' exp ']' | prefixexp '.' NAME
-varlist = var {',' var}
-prefixexp = var | functioncall | '(' exp ')'
-functioncall = prefixexp funcargs | prefixexp ':' NAME funcargs
+var ::= NAME | prefixexp '[' exp ']' | prefixexp '.' NAME
+varlist ::= var {',' var}
+prefixexp ::= var | functioncall | '(' exp ')'
+functioncall ::= prefixexp funcargs | prefixexp ':' NAME funcargs
 
-exp = asexp { binop exp } | unop exp { binop exp }
-ifelseexp = 'if' exp 'then' exp {'elseif' exp 'then' exp} 'else' exp
-asexp = simpleexp ['::' Type]
-stringinterp = INTERP_BEGIN exp { INTERP_MID exp } INTERP_END
-simpleexp = NUMBER | STRING | 'nil' | 'true' | 'false' | '...' | tableconstructor | attributes 'function' funcbody | prefixexp | ifelseexp | stringinterp
-funcargs =  '(' [explist] ')' | tableconstructor | STRING
+exp ::= asexp { binop exp } | unop exp { binop exp }
+ifelseexp ::= 'if' exp 'then' exp {'elseif' exp 'then' exp} 'else' exp
+asexp ::= simpleexp ['::' Type]
+stringinterp ::= INTERP_BEGIN exp { INTERP_MID exp } INTERP_END
+simpleexp ::= NUMBER | STRING | 'nil' | 'true' | 'false' | '...' | tableconstructor | attributes 'function' funcbody | prefixexp | ifelseexp | stringinterp
+funcargs ::=  '(' [explist] ')' | tableconstructor | STRING
 
-tableconstructor = '{' [fieldlist] '}'
-fieldlist = field {fieldsep field} [fieldsep]
-field = '[' exp ']' '=' exp | NAME '=' exp | exp
-fieldsep = ',' | ';'
+tableconstructor ::= '{' [fieldlist] '}'
+fieldlist ::= field {fieldsep field} [fieldsep]
+field ::= '[' exp ']' '=' exp | NAME '=' exp | exp
+fieldsep ::= ',' | ';'
 
-compoundop :: '+=' | '-=' | '*=' | '/=' | '//=' | '%=' | '^=' | '..='
-binop = '+' | '-' | '*' | '/' | '//' | '^' | '%' | '..' | '<' | '<=' | '>' | '>=' | '==' | '~=' | 'and' | 'or'
-unop = '-' | 'not' | '#'
+compoundop ::= '+=' | '-=' | '*=' | '/=' | '//=' | '%=' | '^=' | '..='
+binop ::= '+' | '-' | '*' | '/' | '//' | '^' | '%' | '..' | '<' | '<=' | '>' | '>=' | '==' | '~=' | 'and' | 'or'
+unop ::= '-' | 'not' | '#'
 
 littable ::= '{' [litfieldlist] '}'
 litfieldlist ::= litfield {fieldsep litfield} [fieldsep]
@@ -69,7 +69,7 @@ parattr ::= NAME [pars]
 attribute ::= '@' NAME | '@[' parattr {',' parattr} ']'
 attributes ::= {attribute}
 
-SimpleType =
+SimpleType ::=
     'nil' |
     SingletonType |
     NAME ['.' NAME] [ '<' [TypeParams] '>' ] |
@@ -78,31 +78,31 @@ SimpleType =
     FunctionType |
     '(' Type ')'
 
-SingletonType = STRING | 'true' | 'false'
+SingletonType ::= STRING | 'true' | 'false'
 
-Union = [SimpleType {'?'}] {'|' SimpleType {'?'}}
-Intersection = [SimpleType] {'&' SimpleType}
-Type = Union | Intersection
+Union ::= [SimpleType {'?'}] {'|' SimpleType {'?'}}
+Intersection ::= [SimpleType] {'&' SimpleType}
+Type ::= Union | Intersection
 
-GenericTypePackParameter = NAME '...'
-GenericTypeList = NAME [',' GenericTypeList] | GenericTypePackParameter {',' GenericTypePackParameter}
+GenericTypePackParameter ::= NAME '...'
+GenericTypeList ::= NAME [',' GenericTypeList] | GenericTypePackParameter {',' GenericTypePackParameter}
 
-GenericTypePackParameterWithDefault = NAME '...' '=' (TypePack | VariadicTypePack | GenericTypePack)
-GenericTypeListWithDefaults =
+GenericTypePackParameterWithDefault ::= NAME '...' '=' (TypePack | VariadicTypePack | GenericTypePack)
+GenericTypeListWithDefaults ::=
     NAME ['=' Type] [',' GenericTypeListWithDefaults] |
     GenericTypePackParameterWithDefault {',' GenericTypePackParameterWithDefault}
 
-TypeList = Type [',' TypeList] | '...' Type
-BoundTypeList = [NAME ':'] Type [',' BoundTypeList] | GenericTypePack | VariadicTypePack
-TypeParams = (Type | TypePack | VariadicTypePack | GenericTypePack) [',' TypeParams]
-TypePack = '(' [TypeList] ')'
-GenericTypePack = NAME '...'
-VariadicTypePack = '...' Type
-ReturnType = Type | TypePack | GenericTypePack | VariadicTypePack
-TableIndexer = ['read' | 'write'] '[' Type ']' ':' Type
-TableProp = ['read' | 'write'] NAME ':' Type
-PropList = TableProp [fieldsep PropList] | TableIndexer {fieldsep TableProp} 
+TypeList ::= Type [',' TypeList] | '...' Type
+BoundTypeList ::= [NAME ':'] Type [',' BoundTypeList] | GenericTypePack | VariadicTypePack
+TypeParams ::= (Type | TypePack | VariadicTypePack | GenericTypePack) [',' TypeParams]
+TypePack ::= '(' [TypeList] ')'
+GenericTypePack ::= NAME '...'
+VariadicTypePack ::= '...' Type
+ReturnType ::= Type | TypePack | GenericTypePack | VariadicTypePack
+TableIndexer ::= ['read' | 'write'] '[' Type ']' ':' Type
+TableProp ::= ['read' | 'write'] NAME ':' Type
+PropList ::= TableProp [fieldsep PropList] | TableIndexer {fieldsep TableProp} 
 
-TableType = '{' Type '}' | '{' [PropList] '}'
-FunctionType = ['<' GenericTypeList '>'] '(' [BoundTypeList] ')' '->' ReturnType
+TableType ::= '{' Type '}' | '{' [PropList] '}'
+FunctionType ::= ['<' GenericTypeList '>'] '(' [BoundTypeList] ')' '->' ReturnType
 ```


### PR DESCRIPTION
Replaced all `=` with `::=` to ensure consistency between all assignments in the EBNF grammar.

Fixed a minor issue with the casing of "String" and "Number" in the description above the EBNF grammar. This now matches with how they're used within the grammar.