### PR TITLE
fix typecheck page typo

### DIFF
--- a/_pages/typecheck.md
+++ b/_pages/typecheck.md
@@ -735,7 +735,7 @@ type keys = simple_keyof<person>
 
 In addition to the [types](#types-library) library, type functions have access to:
 
-* `assert`, `errror`, `print`
+* `assert`, `error`, `print`
 * `next`, `ipairs`, `pairs`
 * `select`, `unpack`
 * `getmetatable`, `setmetatable`


### PR DESCRIPTION
Fixes a typo on the typecheck page (errror > error).