### PR TITLE
Removed a duplicate, erroneous occurence of the word table.

### DIFF
--- a/_pages/syntax.md
+++ b/_pages/syntax.md
@@ -207,7 +207,7 @@ for k, v in {1, 4, 9} do
 end
 ```
 
-Iteration can be extended for tables or userdata by implementing the `__iter` metamethod that is called before the iteration begins, and should return an iterator function like `next` (or a custom one):
+Further, iteration can be extended for tables or userdata by implementing the `__iter` metamethod which is called before the iteration begins, and should return an iterator function like `next` (or a custom one):
 
 ```lua
 local obj = { items = {1, 4, 9} }

--- a/_pages/syntax.md
+++ b/_pages/syntax.md
@@ -207,7 +207,7 @@ for k, v in {1, 4, 9} do
 end
 ```
 
-This works for tables but can also be extended for tables or userdata by implementing `__iter` metamethod that is called before the iteration begins, and should return an iterator function like `next` (or a custom one):
+This works for tables but can also be extended for userdata by implementing `__iter` metamethod that is called before the iteration begins, and should return an iterator function like `next` (or a custom one):
 
 ```lua
 local obj = { items = {1, 4, 9} }

--- a/_pages/syntax.md
+++ b/_pages/syntax.md
@@ -207,7 +207,7 @@ for k, v in {1, 4, 9} do
 end
 ```
 
-This works for tables but can also be extended for userdata by implementing `__iter` metamethod that is called before the iteration begins, and should return an iterator function like `next` (or a custom one):
+Iteration can be extended for tables or userdata by implementing the `__iter` metamethod that is called before the iteration begins, and should return an iterator function like `next` (or a custom one):
 
 ```lua
 local obj = { items = {1, 4, 9} }


### PR DESCRIPTION
> This works for tables but can also be extended for tables or userdata...
☝️ Extra occurrence of 'tables'.

> This works for tables but can also be extended for userdata
👍 Removed.