### PR TITLE
Increase share limit

### DIFF
--- a/_includes/repl.html
+++ b/_includes/repl.html
@@ -23,7 +23,7 @@
         text-align: center;
     }
 
-    .button-group > * {
+    .button-group>* {
         display: inline-block;
         margin-right: 10px;
         margin-left: 5px;
@@ -90,7 +90,9 @@
 <script src="assets/js/luau_mode.js"></script>
 <!-- CodeMirror Luau Editor (MUST BE LOADED AFTER CODEMIRROR!) -->
 <script>
-    var MAX_QUERY_PARAM_LENGTH = 0x7FF;
+    // Supposedly the current URL size limit for chrome is 2MB, so we'll cap it at that.
+    // Practically at larger sizes the omnibar won't display it, but it should work just fine
+    var MAX_URL_FRAGMENT_LENGTH = 0x1FFFFF;
     function getValueFromQueryString(key) {
         return new URLSearchParams(window.location.search).get(key);
     }
@@ -98,7 +100,6 @@
         if (!TextEncoder || !CompressionStream || !Response || !Blob) return btoa(str);
         console.info('Using gzip compression');
         console.info('Original string length:', str.length);
-        console.info('base64encoded string length:', btoa(str).length);
         var encoder = new TextEncoder();
         var uint8Array = encoder.encode(str);
 
@@ -109,7 +110,7 @@
         var compressedArrayBuffer = await compressedStream;
         var compressedUint8Array = new Uint8Array(compressedArrayBuffer);
 
-        var compressedString = btoa(String.fromCharCode(...compressedUint8Array));
+        var compressedString = btoa(Array.from(compressedUint8Array, byte => String.fromCharCode(byte)).join(''));
         console.info('compressed string length:', compressedString.length);
         return compressedString
     }
@@ -134,7 +135,7 @@
         if (!str) return null;
         try {
             return await decompressString(decodeURIComponent(str));
-        } catch(e) {
+        } catch (e) {
             console.error('Error parsing share string:', e);
             return null
         }
@@ -223,12 +224,12 @@
             return;
         }
 
-        if (shareStr.length > MAX_QUERY_PARAM_LENGTH) {
+        if (shareStr.length > MAX_URL_FRAGMENT_LENGTH) {
             alert("Source code is too long to be shared.");
             return;
         }
 
-        window.history.pushState({}, document.title, "?share=" + shareStr);
+        window.history.pushState({}, document.title, "#" + shareStr);
 
         if (navigator.clipboard) {
             try {
@@ -245,7 +246,10 @@
     }
 
     async function loadSharedString() {
-        var sharedCode = await decodeShareString(getValueFromQueryString("share"));
+        var sharedCode = await decodeShareString(
+            window.location.hash.substring(1) || // substring to remove the leading '#'
+            getValueFromQueryString("share") // for backwards compatibility
+        );
         if (!sharedCode) return;
         editor.setValue(sharedCode);
     }


### PR DESCRIPTION
## Problem

The current share feature has a hard limit of 2047 characters after gzip and url-encoding. This is due to browser limitations on how long a query param value can be.

Also it doesn't support sharing code with emojis.

## Solution

It turns out that the fragment (#) part of the url is more suited to this purpose than the query param. It actually isn't sent to the server and instead is only parsed on the client. Because of that, browsers don't restrict the size of the fragment portion of the URL. Practically, chrome does limit the size of the URL to 2MB so that's what I set as the limit.

Gemini Deep Research actually discovered this for me, although I did write all of the code by hand: https://g.co/gemini/share/9712e01a0afe

Supporting unicode was as simple as processing each character in the array buffer one by one instead of all at once. This is probably slower but sharing doesn't have to be realtime

Example:

I went ahead and copied an entire copy of Frankenstein. Attempting to run the "code" will crash the interpreter but the share function works just fine!


https://github.com/user-attachments/assets/a1c32274-f3e0-48e1-996e-44bade63306e