### PR TITLE
Document `rawlen`

### DIFF
--- a/_pages/library.md
+++ b/_pages/library.md
@@ -81,7 +81,7 @@ function rawget<K, V>(t: { [K]: V }, k: K): V?
 Performs a table lookup with index `k` and returns the resulting value, if present in the table, or nil. This operation bypasses metatables/`__index`.
 
 ```
-function rawlen<K, V>(obj: { [K]: V } | string): number
+function rawlen<K, V>(t: { [K]: V } | string): number
 ```
 
 Returns the raw length of the table or string. If it is a string, this operation is identical to `#str` or `string.len(str)`. This operation bypasses metatables/`__len`.


### PR DESCRIPTION
`rawlen` is a builtin global [exposed by Luau's standard library](https://github.com/luau-lang/luau/blob/master/VM/src/lbaselib.cpp#L492), however it isn't present in the docs. This PR documents its behavior. The signature is the one used in https://github.com/luau-lang/luau/blob/master/Analysis/src/EmbeddedBuiltinDefinitions.cpp#L36.