### PR TITLE
Add typechecker to demo and support multiple error line highlighting

### DIFF
--- a/_includes/repl.html
+++ b/_includes/repl.html
@@ -232,7 +232,7 @@
 
             var err_line = parseInt(err_text);
             if (err_line) {
-                lastError = editor.addLineClass(err_line - 1, "background", "line-error");
+                lastErrors.push(editor.addLineClass(err_line - 1, "background", "line-error"));
             }
         }
     }


### PR DESCRIPTION
Once the Luau WASM is updated in the luau-lang releases, I'll open this PR that adds our typechecker to the demo!

<img width="1285" height="908" alt="image" src="https://github.com/user-attachments/assets/f7e1f9d0-9d08-420e-9732-d0e7e7852767" />

Closes #54