### PR TITLE
Add playground embeds in place of lua/luau code blocks

### DIFF
--- a/next/astro.config.mjs
+++ b/next/astro.config.mjs
@@ -4,10 +4,15 @@ import starlight from "@astrojs/starlight";
 import starlightBlog from 'starlight-blog';
 
 import tailwindcss from "@tailwindcss/vite";
+import remarkLuauPlayground from "./src/plugins/remark-luau-playground";
 
 // https://astro.build/config
 export default defineConfig({
   redirects: {},
+
+  markdown: {
+    remarkPlugins: [remarkLuauPlayground],
+  },
 
   integrations: [
     starlight({

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -12,9 +12,14 @@
         "@astrojs/starlight-tailwind": "^4.0.2",
         "@tailwindcss/vite": "^4.1.18",
         "astro": "^5.6.1",
+        "lz-string": "^1.5.0",
         "sharp": "^0.34.2",
         "starlight-blog": "^0.25.2",
-        "tailwindcss": "^4.1.18"
+        "tailwindcss": "^4.1.18",
+        "unist-util-visit": "^5.0.0"
+      },
+      "devDependencies": {
+        "@types/lz-string": "^1.3.34"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -123,6 +128,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.37.1.tgz",
       "integrity": "sha512-STNsR5PaDoiW4IgcX17Fp42FfyqwuweWPts/EWEMcFPAeg9Nvpu3UvVCorasYrgfJgaJTeydsOV++0ACA1KYDA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/markdown-remark": "^6.3.1",
         "@astrojs/mdx": "^4.2.3",
@@ -2064,6 +2070,13 @@
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "license": "MIT"
     },
+    "node_modules/@types/lz-string": {
+      "version": "1.3.34",
+      "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@types/lz-string/-/lz-string-1.3.34.tgz",
+      "integrity": "sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2129,6 +2142,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2289,6 +2303,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.5.tgz",
       "integrity": "sha512-QeuM4xzTR0QuXFDNlGVW0BW7rcquKFIkylaPeM4ufii0/RRiPTYtwxDYVZ3KfiMRuuc+nbLD0214kMKTvz/yvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -4260,6 +4275,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4307,6 +4331,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5701,6 +5726,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6172,6 +6198,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.4.tgz",
       "integrity": "sha512-YpXaaArg0MvrnJpvduEDYIp7uGOqKXbH9NsHGQ6SxKCOsNAjZF018MmxefFUulVP2KLtiGw1UvZbr+/ekjvlDg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6506,7 +6533,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -6809,7 +6837,7 @@
     },
     "node_modules/unist-util-visit": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
       "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
       "license": "MIT",
       "dependencies": {
@@ -6998,6 +7026,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7196,6 +7225,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/next/package.json
+++ b/next/package.json
@@ -14,8 +14,13 @@
     "@astrojs/starlight-tailwind": "^4.0.2",
     "@tailwindcss/vite": "^4.1.18",
     "astro": "^5.6.1",
+    "lz-string": "^1.5.0",
     "sharp": "^0.34.2",
     "starlight-blog": "^0.25.2",
-    "tailwindcss": "^4.1.18"
+    "tailwindcss": "^4.1.18",
+    "unist-util-visit": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/lz-string": "^1.3.34"
   }
 }

--- a/next/src/plugins/remark-luau-playground.ts
+++ b/next/src/plugins/remark-luau-playground.ts
@@ -1,0 +1,173 @@
+/**
+ * Remark plugin that transforms luau/lua code blocks into interactive playground embeds
+ * 
+ * Supports multi-file definitions using the --!file directive:
+ * 
+ * ```luau
+ * --!file main.luau
+ * local helper = require("./helper")
+ * print(helper.greet("World"))
+ * 
+ * --!file helper.luau
+ * local M = {}
+ * function M.greet(name: string): string
+ *     return "Hello, " .. name
+ * end
+ * return M
+ * ```
+ */
+
+import type { Root, Code } from 'mdast';
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
+import LZString from 'lz-string';
+
+const PLAYGROUND_URL = 'https://play.luau.org';
+
+interface ShareState {
+  files: Record<string, string>;
+  active: string;
+  v: number;
+}
+
+interface PluginOptions {
+  /** Theme: "light" | "dark" | "auto" (default: "auto") */
+  theme?: 'light' | 'dark' | 'auto';
+  /** Override the playground URL */
+  baseUrl?: string;
+}
+
+/**
+ * Calculate iframe height based on number of lines in the active file
+ * 
+ * Layout breakdown:
+ * - 44px: top bar
+ * - 12px: top padding
+ * - 19.6px per line (14px font * 1.4 line height)
+ * - 12px: bottom padding
+ * - 2px: fudge factor for sub-pixel rounding
+ */
+function calculateHeight(files: Record<string, string>): string {
+  const activeFile = Object.keys(files)[0] || 'main.luau';
+  const content = files[activeFile] || '';
+  const lineCount = content.split('\n').length;
+  
+  const topBar = 44;
+  const verticalPadding = 12 * 2; // top + bottom
+  const lineHeight = 19.6;
+  const fudge = 2;
+  
+  const height = topBar + verticalPadding + (lineCount * lineHeight) + fudge;
+  return `${Math.ceil(height)}px`;
+}
+
+/**
+ * Encode files to URL-safe format (same as main playground)
+ */
+function encodeFiles(files: Record<string, string>, activeFile: string): string {
+  const state: ShareState = {
+    files,
+    active: activeFile,
+    v: 1,
+  };
+  return LZString.compressToEncodedURIComponent(JSON.stringify(state));
+}
+
+/**
+ * Parse code content for multi-file definitions using --!file directive
+ */
+function parseFiles(code: string): Record<string, string> {
+  const files: Record<string, string> = {};
+  const lines = code.split('\n');
+  
+  let currentFile = 'main.luau';
+  let currentContent: string[] = [];
+  let hasFileDirective = false;
+  
+  for (const line of lines) {
+    const match = line.match(/^--!file\s+(.+)$/);
+    if (match) {
+      // Save previous file content if any
+      if (hasFileDirective && currentContent.length > 0) {
+        files[currentFile] = currentContent.join('\n').trim();
+      }
+      currentFile = match[1].trim();
+      currentContent = [];
+      hasFileDirective = true;
+    } else {
+      currentContent.push(line);
+    }
+  }
+  
+  // Save the last file's content
+  const content = currentContent.join('\n').trim();
+  if (hasFileDirective) {
+    files[currentFile] = content;
+  } else {
+    // No --!file directives, treat entire content as main.luau
+    files['main.luau'] = code.trim();
+  }
+  
+  return files;
+}
+
+/**
+ * Generate iframe HTML for the playground embed
+ */
+function generateIframeHtml(
+  files: Record<string, string>,
+  options: Required<PluginOptions>
+): string {
+  const activeFile = Object.keys(files)[0] || 'main.luau';
+  const encoded = encodeFiles(files, activeFile);
+  const src = `${options.baseUrl}/?embed=true&theme=${options.theme}#code=${encoded}`;
+  const height = calculateHeight(files);
+  
+  return `<iframe
+  src="${src}"
+  style="width: 100%; height: ${height}; border: 1px solid var(--sl-color-gray-5);"
+  loading="lazy"
+  allowfullscreen
+  allow="clipboard-write"
+  title="Luau Playground"
+></iframe>`;
+}
+
+/**
+ * Remark plugin to transform luau/lua code blocks into playground embeds
+ */
+const remarkLuauPlayground: Plugin<[PluginOptions?], Root> = (options = {}) => {
+  const opts: Required<PluginOptions> = {
+    theme: options.theme ?? 'auto',
+    baseUrl: options.baseUrl ?? PLAYGROUND_URL,
+  };
+
+  return (tree: Root) => {
+    visit(tree, 'code', (node: Code, index, parent) => {
+      // Only process lua and luau code blocks
+      if (!node.lang || !['lua', 'luau'].includes(node.lang)) {
+        return;
+      }
+
+      if (index === undefined || !parent) {
+        return;
+      }
+
+      // Parse the code for multi-file definitions
+      const files = parseFiles(node.value);
+      
+      // Generate the iframe HTML
+      const html = generateIframeHtml(files, opts);
+
+      // Replace the code node with an HTML node
+      (parent.children as any[])[index] = {
+        type: 'html',
+        value: html,
+      };
+    });
+  };
+};
+
+export default remarkLuauPlayground;
+export { remarkLuauPlayground, parseFiles, encodeFiles };
+


### PR DESCRIPTION
<img width="2793" height="1884" alt="image" src="https://github.com/user-attachments/assets/e3088978-b9ed-41d4-82a4-be796ccb102d" />

this does make a lot of the examples look wrong lol. might need to also expose strict/nonstrict/nocheck options in the codeblock? maybe with old and new solver to show off the differences, too