### PR TITLE
Add all the redirects for the typecheck category and the demo page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,7 +12,19 @@ import remarkLuauPlayground from "./src/plugins/remark-luau-playground";
 export default defineConfig({
   site: 'https://luau.org',
 
-  redirects: {},
+  redirects: {
+    "/demo": "https://play.luau.org",
+    "/typecheck": "/types",
+    "/typecheck/basic-types": "/types/basic-types",
+    "/typecheck/considerations": "/types/considerations",
+    "/typecheck/generics": "/types/generics",
+    "/typecheck/object-oriented-programs": "/types/object-oriented-programs",
+    "/typecheck/overview": "/types/",
+    "/typecheck/refinements": "/types/refinements",
+    "/typecheck/tables": "/types/tables",
+    "/typecheck/type-functions": "/types/type-functions",
+    "/typecheck/unions-and-intersections": "/types/unions-and-intersections",
+  },
 
   markdown: {
     remarkPlugins: [remarkLuauPlayground],


### PR DESCRIPTION
We moved the entire typechecking category to a shorter stub, but we need to retain links. Likewise, the demo page is gone because the playground superseded it. We should setup redirects for both, so that the URL stays functional wherever it may be.