### PR TITLE
Change lint page title to Linter

### DIFF
--- a/src/content/docs/getting-started/lint.md
+++ b/src/content/docs/getting-started/lint.md
@@ -7,7 +7,7 @@ sidebar:
 
 Luau comes with a set of linting passes, that help make sure that the code is correct and consistent. Unlike the type checker, that models the behavior of the code thoroughly and points toward type mismatches that are likely to result in runtime errors, the linter is more opinionated and produces warnings that can often be safely ignored, although it's recommended to keep the code clean of the warnings.
 
-Linter produces many different types of warnings; many of these are enabled by default, and can be suppressed by declaring `--!nolint NAME` at the top of the file. In dire situations `--!nolint` at the top of the file can be used to completely disable all warnings (note that the type checker is still active, and requires a separate `--!nocheck` declaration).
+Luau's Linter produces many different types of warnings; many of these are enabled by default, and can be suppressed by declaring `--!nolint NAME` at the top of the file. In dire situations `--!nolint` at the top of the file can be used to completely disable all warnings (note that the type checker is still active, and requires a separate `--!nocheck` declaration).
 
 The rest of this page documents all warnings produced by the linter; each warning has a name and a numeric code, the latter is used when displaying warnings. Note that the in-browser version of Luau on this website does not currently use the linter.
 

--- a/src/content/docs/getting-started/lint.md
+++ b/src/content/docs/getting-started/lint.md
@@ -1,6 +1,6 @@
 ---
 slug: lint
-title: Luau's linter
+title: Linter
 sidebar:
   order: 4
 ---
@@ -317,7 +317,7 @@ In addition, when type information is present, this warning will be emitted when
 local message = { data = { 1, 2, 3 } }
 
 if #message == 0 then -- Using '#' on a table without an array part is likely a bug
-end 
+end
 ```
 
 ## DuplicateCondition (24)


### PR DESCRIPTION
Its already known from context clues that its a Linter provided by luau, and if not then the first 7 words in the pages body "Luau comes with a set of linting passes" would clear up any misconceptions.