### PR TITLE
change from local to root rss-link

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -69,7 +69,7 @@ export default defineConfig({
         {
           icon: "rss",
           label: "RSS Feed",
-          href: "./feed.xml",
+          href: "/feed.xml",
         },
       ],
       sidebar: [


### PR DESCRIPTION
I guess the link should point to the root of the site regardless of the current page.
Otherwise, on any page other than the main one, the rss button will redirect to a non-existent page (404)