### PR TITLE
Set default code block language highlighting to Luau

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,7 @@ import starlight from "@astrojs/starlight";
 
 import tailwindcss from "@tailwindcss/vite";
 import remarkLuauPlayground from "./src/plugins/remark-luau-playground";
+import remarkLuauCodeBlocks from "./src/plugins/remark-luau-code-blocks";
 
 // https://astro.build/config
 export default defineConfig({
@@ -27,7 +28,7 @@ export default defineConfig({
   },
 
   markdown: {
-    remarkPlugins: [remarkLuauPlayground],
+    remarkPlugins: [remarkLuauPlayground, remarkLuauCodeBlocks],
   },
 
   integrations: [
@@ -35,8 +36,10 @@ export default defineConfig({
       name: "luau-playground",
       hooks: {
         'astro:config:setup': function({ addWatchFile }) {
-          const remarkPlugin = path.resolve("src", "plugins", "remark-luau-playground.ts");
-          addWatchFile(remarkPlugin);
+          const remarkPlaygroundPlugin = path.resolve("src", "plugins", "remark-luau-playground.ts");
+          const remarkCodeBlocksPlugin = path.resolve("src", "plugins", "remark-luau-code-blocks.ts");
+          addWatchFile(remarkPlaygroundPlugin);
+          addWatchFile(remarkCodeBlocksPlugin);
         }
       }
     },

--- a/src/plugins/remark-luau-code-blocks.ts
+++ b/src/plugins/remark-luau-code-blocks.ts
@@ -1,0 +1,17 @@
+import type { Root, Code } from 'mdast';
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
+
+/**
+ * Remark plugin to automatically set code blocks to highlight as Luau
+ */
+const remarkLuauCodeBlocks: Plugin<[], Root> = (options = {}) => {
+  return (tree: Root) => {
+    visit(tree, 'code', (node: Code) => {
+      if (!node.lang)
+        node.lang = "luau";
+    });
+  };
+};
+
+export default remarkLuauCodeBlocks;


### PR DESCRIPTION
Implements a remark plugin so that when a language is not specified for code blocks, `luau` is set.
Visible in the standard library reference